### PR TITLE
Implemented methods to sort products & fixed availability query on Computer controller

### DIFF
--- a/BangazonAPI/Controllers/ComputerController.cs
+++ b/BangazonAPI/Controllers/ComputerController.cs
@@ -40,7 +40,7 @@ namespace BangazonAPI.Controllers
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = @"
-                                        SELECT Id, PurchaseDate,  Make, Model
+                                        SELECT Id, PurchaseDate, DecomissionDate, Make, Model
                                         FROM Computer
                                         ";
 
@@ -53,12 +53,15 @@ namespace BangazonAPI.Controllers
                         {
                             Id = reader.GetInt32(reader.GetOrdinal("Id")),
                             PurchaseDate = reader.GetDateTime(reader.GetOrdinal("PurchaseDate")),
-                            //DecomissionDate = reader.GetDateTime(reader.GetOrdinal("DecomissionDate")),
+                  
                             Make = reader.GetString(reader.GetOrdinal("Make")),
                             Model = reader.GetString(reader.GetOrdinal("Model"))
 
                         };
-
+                        if (!reader.IsDBNull(reader.GetOrdinal("DecomissionDate")))
+                        {
+                            computer.DecomissionDate = reader.GetDateTime(reader.GetOrdinal("DecomissionDate"));
+                        }
                         computers.Add(computer);
                     }
                     reader.Close();
@@ -71,7 +74,7 @@ namespace BangazonAPI.Controllers
 
 
         [HttpGet("{id}", Name = "GetComputer")]
-        public async Task<IActionResult> Get([FromRoute] int id)
+        public async Task<IActionResult> Get([FromRoute] int id, [FromQuery] string include)
         {
             using (SqlConnection conn = Connection)
             {
@@ -80,9 +83,10 @@ namespace BangazonAPI.Controllers
                 {
                     cmd.CommandText = @"
                         SELECT
-                            Id, PurchaseDate,  Make, Model
+                            Id, PurchaseDate, DecomissionDate, Make, Model
                         FROM Computer
                         WHERE Id = @id";
+
                     cmd.Parameters.Add(new SqlParameter("@id", id));
                     SqlDataReader reader = cmd.ExecuteReader();
 
@@ -95,7 +99,7 @@ namespace BangazonAPI.Controllers
                             Id = reader.GetInt32(reader.GetOrdinal("Id")),
 
                             PurchaseDate = reader.GetDateTime(reader.GetOrdinal("PurchaseDate")),
-                           // DecomissionDate = reader.GetDateTime(reader.GetOrdinal("DecomissionDate")),
+                            DecomissionDate = reader.GetDateTime(reader.GetOrdinal("DecomissionDate")),
                             Make = reader.GetString(reader.GetOrdinal("Make")),
                             Model = reader.GetString(reader.GetOrdinal("Model"))
 
@@ -117,11 +121,11 @@ namespace BangazonAPI.Controllers
                 conn.Open();
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
-                    cmd.CommandText = @"INSERT INTO Computer (PurchaseDate,  Make, Model)
+                    cmd.CommandText = @"INSERT INTO Computer (PurchaseDate, DecomissionDate Make, Model)
                                         OUTPUT INSERTED.Id
                                         VALUES (@purchaseDate,  @make, @model)";
                     cmd.Parameters.Add(new SqlParameter("@purchaseDate", computer.PurchaseDate));
-                   // cmd.Parameters.Add(new SqlParameter("@decomissionDate", computer.DecomissionDate));
+                    cmd.Parameters.Add(new SqlParameter("@decomissionDate", computer.DecomissionDate));
                     cmd.Parameters.Add(new SqlParameter("@make", computer.Make));
                     cmd.Parameters.Add(new SqlParameter("@model", computer.Model));
 
@@ -145,12 +149,13 @@ namespace BangazonAPI.Controllers
                     {
                         cmd.CommandText = @"UPDATE Computer
                                             SET PurchaseDate = @purchaseDate,
+                                                DecomissionDate = @decomissionDate
                                            
                                                 Make = @make
                                                 Model = @model
                                             WHERE Id = @id";
                         cmd.Parameters.Add(new SqlParameter("@purchaseDate", computer.PurchaseDate));
-                       // cmd.Parameters.Add(new SqlParameter("@decomissionDate", computer.DecomissionDate));
+                        cmd.Parameters.Add(new SqlParameter("@decomissionDate", computer.DecomissionDate));
                         cmd.Parameters.Add(new SqlParameter("@make", computer.Make));
                         cmd.Parameters.Add(new SqlParameter("@model", computer.Model));
                         cmd.Parameters.Add(new SqlParameter("@id", id));

--- a/BangazonAPI/Controllers/ComputerController.cs
+++ b/BangazonAPI/Controllers/ComputerController.cs
@@ -74,27 +74,33 @@ namespace BangazonAPI.Controllers
                     {
                         if (reader.IsDBNull(reader.GetOrdinal("ComputerId")))
                         {
-
-                            Computer computer = new Computer
+                            // Chain another if statement that makes sure ONLY computers with null decomission dates are displaying
+                            if (reader.IsDBNull(reader.GetOrdinal("DecomissionDate")))
                             {
-                                Id = reader.GetInt32(reader.GetOrdinal("Id")),
-                                PurchaseDate = reader.GetDateTime(reader.GetOrdinal("PurchaseDate")),
-                                Make = reader.GetString(reader.GetOrdinal("Make")),
-                                Model = reader.GetString(reader.GetOrdinal("Model"))
 
-                            };
+                                Computer computer = new Computer
+                                {
+                                    Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                                    PurchaseDate = reader.GetDateTime(reader.GetOrdinal("PurchaseDate")),
+                                    Make = reader.GetString(reader.GetOrdinal("Make")),
+                                    Model = reader.GetString(reader.GetOrdinal("Model"))
 
-                            if (!reader.IsDBNull(reader.GetOrdinal("DecomissionDate")))
-                            {
-                                computer.DecomissionDate = reader.GetDateTime(reader.GetOrdinal("DecomissionDate"));
-                            }
-                            else
-                            {
-                                computer.DecomissionDate = null;
-                            }
+                                };
 
+                            //Don't need this shit
+
+                            //if (!reader.IsDBNull(reader.GetOrdinal("DecomissionDate")))
+                            //{
+                            //    computer.DecomissionDate = reader.GetDateTime(reader.GetOrdinal("DecomissionDate"));
+                            //}
+                            //else
+                            //{
+                            //    computer.DecomissionDate = null;
+                            //}
 
                             computers.Add(computer);
+
+                            }
                         }
                     }
                     reader.Close();
@@ -111,10 +117,13 @@ namespace BangazonAPI.Controllers
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = @"
-                     SELECT c.Id, c.PurchaseDate, c.DecomissionDate, c.Make, c.Model
+                     SELECT c.Id, c.PurchaseDate, c.DecomissionDate, c.Make, c.Model, e.ComputerId
                     FROM Computer c
-                    INNER JOIN Employee e
+                    LEFT JOIN Employee e
                     ON e.ComputerId = c.Id";
+
+                    // INNER JOIN Employee e
+                    // ^^^ Don't use this since it doesn't capture the decomissioned computers with no employee assigned
 
 
                     SqlDataReader reader = cmd.ExecuteReader();
@@ -123,24 +132,31 @@ namespace BangazonAPI.Controllers
 
                     while (reader.Read())
                     {
-                        Computer computer = new Computer
+                        // Use an IF statement to get all computers currently assigned to an employee OR!!!! to get all computers with NO employee assigned AND with a decomission date
+                        if (!reader.IsDBNull(reader.GetOrdinal("ComputerId")) || reader.IsDBNull(reader.GetOrdinal("ComputerId")) && !reader.IsDBNull(reader.GetOrdinal("DecomissionDate")))
                         {
-                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
-                            PurchaseDate = reader.GetDateTime(reader.GetOrdinal("PurchaseDate")),
-                            Make = reader.GetString(reader.GetOrdinal("Make")),
-                            Model = reader.GetString(reader.GetOrdinal("Model"))
+                            Computer computer = new Computer
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                                PurchaseDate = reader.GetDateTime(reader.GetOrdinal("PurchaseDate")),
+                                Make = reader.GetString(reader.GetOrdinal("Make")),
+                                Model = reader.GetString(reader.GetOrdinal("Model"))
+                            };
 
-                        };
 
-                        if (!reader.IsDBNull(reader.GetOrdinal("DecomissionDate")))
-                        {
-                            computer.DecomissionDate = reader.GetDateTime(reader.GetOrdinal("DecomissionDate"));
+                            // Don't need this shit
+                            //if (!reader.IsDBNull(reader.GetOrdinal("DecomissionDate")))
+                            //{
+                            //    computer.DecomissionDate = reader.GetDateTime(reader.GetOrdinal("DecomissionDate"));
+                            //}
+                            //else
+                            //{
+                            //    computer.DecomissionDate = null;
+                            //}
+
+                            computers.Add(computer);
                         }
-                        else
-                        {
-                            computer.DecomissionDate = null;
-                        }
-                        computers.Add(computer);
+
                     }
                     reader.Close();
 

--- a/BangazonAPI/Controllers/OrderController.cs
+++ b/BangazonAPI/Controllers/OrderController.cs
@@ -206,7 +206,7 @@ namespace BangazonAPI.Controllers
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = @"
-                        SELECT Id, CustomerId, CustomerPaymentTypeId
+                        SELECT Id, CustomerId, UserPaymentTypeId
                         FROM Order
                         WHERE Id = @id";
                     cmd.Parameters.Add(new SqlParameter("@id", id));

--- a/BangazonAPI/Controllers/ProductController.cs
+++ b/BangazonAPI/Controllers/ProductController.cs
@@ -32,7 +32,8 @@ namespace BangazonAPI.Controllers
         [HttpGet]
         public async Task<IActionResult> Get(
             [FromQuery] string q,
-            [FromQuery] string sortBy)
+            [FromQuery] string sortBy,
+            [FromQuery] string asc)
         {
             using (SqlConnection conn = Connection)
             {
@@ -52,6 +53,26 @@ namespace BangazonAPI.Controllers
                     if (sortBy == "recent")
                     {
                         cmd.CommandText += " ORDER BY DateAdded Desc";
+                    }
+
+                    if (sortBy == "price" & asc == "true")
+                    {
+                        cmd.CommandText += " ORDER BY Price Asc";
+                    }
+
+                    if (sortBy == "price" & asc == "false")
+                    {
+                        cmd.CommandText += " ORDER BY Price Desc";
+                    }
+
+                    if (sortBy == "popularity")
+                    {
+                        cmd.CommandText = @"SELECT p.Id, p.DateAdded, p.ProductTypeId, p.CustomerId, p.Price, p.Title, p.[Description], Count(p.Id) AS Count
+                            FROM Product P
+                            LEFT JOIN OrderProduct op
+                            ON op.ProductId = p.Id
+                            GROUP BY p.Id, p.DateAdded, p.ProductTypeId, p.CustomerId, p.Price, p.Title, p.[Description]
+                            ORDER BY Count Desc";
                     }
 
 

--- a/BangazonAPI/Models/Computer.cs
+++ b/BangazonAPI/Models/Computer.cs
@@ -9,9 +9,9 @@ namespace BangazonAPI.Models
     {
         public int Id { get; set; }
         public DateTime PurchaseDate { get; set; }
-        public DateTime DecomissionDate { get; set; }
+        public DateTime? DecomissionDate { get; set; }
         public string Make { get; set; }
         public string Model { get; set; }
-        public List<Computer> Computers { get; set; }
+      
     }
 }


### PR DESCRIPTION
You can now sort `PRODUCTS` by **PRICE** (both ascending & descending):

```api/product?sortBy=price&asc=true```
```api/product?sortBy=price&asc=false```

You can also sort `PRODUCTS` by **POPULARITY** (products with most orders) 

```api/product?sortBy=popularity``` (note this will STILL be identical to the unsorted products, because that is the order of their popularity)

You can sort `COMPUTERS` by **AVAILABILITY**. Computers that **ARE** available should **NOT** have a decommission date. 

Computers that are **NOT** available should be:

A) assigned to an employee 

OR 

B) unassigned, but decommissioned.

```/api/computer?available=true```
```/api/computer?available=false```