### PR TITLE
Gdf training program extra req

### DIFF
--- a/BangazonAPI/Controllers/TrainingProgramsController.cs
+++ b/BangazonAPI/Controllers/TrainingProgramsController.cs
@@ -46,6 +46,7 @@ namespace BangazonAPI.Controllers
                                         SELECT Id, Name, StartDate, EndDate, MaxAttendees
                                         FROM TrainingProgram
                                         WHERE 1=1
+                                        AND StartDate >= GETDATE()
                                         ";
 
                     SqlDataReader reader = cmd.ExecuteReader();
@@ -147,17 +148,22 @@ namespace BangazonAPI.Controllers
                 conn.Open();
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
-                    cmd.CommandText = @"INSERT INTO TrainingProgram (Name, StartDate, EndDate, MaxAttendees)
+                    if (trainingProgram.StartDate > DateTime.Now && trainingProgram.EndDate > trainingProgram.StartDate )
+                    {
+                        cmd.CommandText = @"INSERT INTO TrainingProgram (Name, StartDate, EndDate, MaxAttendees)
                                         OUTPUT INSERTED.Id
                                         VALUES (@name, @startDate, @endDate, @maxAttendees)";
-                    cmd.Parameters.Add(new SqlParameter("@name", trainingProgram.Name));
-                    cmd.Parameters.Add(new SqlParameter("@startDate", trainingProgram.StartDate));
-                    cmd.Parameters.Add(new SqlParameter("@endDate", trainingProgram.EndDate));
-                    cmd.Parameters.Add(new SqlParameter("@maxAttendees", trainingProgram.MaxAttendees));
+                        cmd.Parameters.Add(new SqlParameter("@name", trainingProgram.Name));
+                        cmd.Parameters.Add(new SqlParameter("@startDate", trainingProgram.StartDate));
+                        cmd.Parameters.Add(new SqlParameter("@endDate", trainingProgram.EndDate));
+                        cmd.Parameters.Add(new SqlParameter("@maxAttendees", trainingProgram.MaxAttendees)); 
 
+                    }
+                    
                     int newId = (int)cmd.ExecuteScalar();
                     trainingProgram.Id = newId;
                     return CreatedAtRoute("GetTrainingProgram", new { id = newId }, trainingProgram);
+
                 }
             }
         }
@@ -299,7 +305,6 @@ namespace BangazonAPI.Controllers
 
         // DELETE -- Remove employee from trainingProgram
         [HttpDelete("{id}/employees/{employeeId}")]
-        [Route("{id}/employees/{employeeId}")]
 
         public async Task<IActionResult> DeleteEmployeeFromProgram([FromRoute] int id, [FromRoute] int employeeId)
         {


### PR DESCRIPTION
- The `api/trainingPrograms` route only includes training programs that are upcoming. It does not include any programs in the past.

- When getting a single training program by Id, the json response always includes the list of employees that are currently enrolled in the program.

- When added a new training program, the start date must be in the future and the end date must be after the start date. API will throw errors otherwise.